### PR TITLE
Only tag the latest image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Build image
         run: |
           docker version
-          docker image build --pull --platform=linux/amd64 --tag=ghcr.io/$GITHUB_REPOSITORY:${{ github.ref_name}} --tag=ghcr.io/$GITHUB_REPOSITORY:latest - < Dockerfile
+          docker image build --pull --platform=linux/amd64 --tag=ghcr.io/$GITHUB_REPOSITORY:latest - < Dockerfile
       - name: Push image
         run: |
           docker version


### PR DESCRIPTION
I decided not to semver tag images because I don't think it's a good idea to pin this image. Even though not pinning can prevent breakages, it can also leave you without security updates and bug fixes. I'm making a judegement call that the risk of breakage is sufficiently low for this small image that it's best to use `:latest`.