### PR TITLE
Remove unnecessary docker push flag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,4 +25,4 @@ jobs:
       - name: Push image
         run: |
           docker version
-          docker image push --all-tags ghcr.io/$GITHUB_REPOSITORY
+          docker image push ghcr.io/$GITHUB_REPOSITORY:latest


### PR DESCRIPTION
- Only tag the latest image
- Remove unnecessary --all-tags flag from `docker push`
