### PR TITLE
Run a release on pushes to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,10 @@ name: Weekly Release
 # Build a fresh image every week.
 on:
   schedule:
-    - cron: '0 14 * * 1' # run at 9am eastern time every Monday
+    - cron: '0 14 * * 1' # run at 9am eastern US time every Monday
+  push:
+    branches:
+      - main
 
 env:
   DOCKER_BUILDKIT: "1"


### PR DESCRIPTION
This should only happen on merges to main, since main is a protected
branch and you can only "push" by merging an MR because of the
protection rules.
