### PR TITLE
fix: update base image to new home

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,18 +6,15 @@
     "customizations": {
         "vscode": {
             "settings": {
-                "[dockerfile]": {
-                    "editor.defaultFormatter": "ms-azuretools.vscode-docker"
-                },
-                "editor.formatOnSave": true,
                 "files.insertFinalNewline": true,
                 "files.trimFinalNewlines": true,
-                "files.trimTrailingWhitespace": true
+                "files.trimTrailingWhitespace": true,
             },
             "extensions": [
                 "davidanson.vscode-markdownlint",
-                "ms-azuretools.vscode-docker",
-                "redhat.vscode-yaml"
+                "docker.docker",
+                "ms-azuretools.vscode-containers",
+                "redhat.vscode-yaml",
             ]
         }
     }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,8 @@
 {
     "recommendations": [
         "davidanson.vscode-markdownlint",
-        "ms-azuretools.vscode-docker",
+        "docker.docker",
+        "ms-azuretools.vscode-containers",
         "redhat.vscode-yaml",
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,4 @@
 {
-    "[dockerfile]": {
-        "editor.defaultFormatter": "ms-azuretools.vscode-docker"
-    },
-    "editor.formatOnSave": true,
     "files.insertFinalNewline": true,
     "files.trimFinalNewlines": true,
     "files.trimTrailingWhitespace": true,

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM mcr.microsoft.com/vscode/devcontainers/base:alpine
+FROM mcr.microsoft.com/devcontainers/base:alpine
 
 LABEL org.opencontainers.image.authors="Ryan Boehning <1250684+ryboe@users.noreply.github.com>"
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ for a custom [Codespace](https://github.com/features/codespaces) project.
 
 ## Features
 
-Since it's based on the `mcr.microsoft.com/vscode/devcontainers/base:alpine`
+Since it's based on the `mcr.microsoft.com/devcontainers/base:alpine`
 image, it supports all Codespace features. In addition, it has these changes:
 
 1. The default user will be `vscode`.


### PR DESCRIPTION
The `mcr.microsoft.com/vscode/devcontainers` path was [deprecated in 2023](https://github.com/microsoft/vscode-dev-containers). The new path is [mcr.microsoft.com/devcontainers](https://github.com/devcontainers/images/blob/main/src/base-alpine/README.md).

The recommended VS Code docker extensions have also changed. Unfortunately, [the new ms-azuretools.vscode-containers extesion](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-containers) extension doesn't format Dockerfiles. Hopefully we'll gain that feature back through [the new docker.docker extension](https://marketplace.visualstudio.com/items?itemName=docker.docker).
