### PR TITLE
fix: bring back Dockerfile formatting

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,15 +6,18 @@
     "customizations": {
         "vscode": {
             "settings": {
+                "[dockerfile]": {
+                    "editor.defaultFormatter": "ms-azuretools.vscode-containers"
+                },
                 "files.insertFinalNewline": true,
                 "files.trimFinalNewlines": true,
-                "files.trimTrailingWhitespace": true,
+                "files.trimTrailingWhitespace": true
             },
             "extensions": [
                 "davidanson.vscode-markdownlint",
                 "docker.docker",
                 "ms-azuretools.vscode-containers",
-                "redhat.vscode-yaml",
+                "redhat.vscode-yaml"
             ]
         }
     }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,6 +3,6 @@
         "davidanson.vscode-markdownlint",
         "docker.docker",
         "ms-azuretools.vscode-containers",
-        "redhat.vscode-yaml",
+        "redhat.vscode-yaml"
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,8 @@
 {
+    "[dockerfile]": {
+        "editor.defaultFormatter": "ms-azuretools.vscode-containers"
+    },
     "files.insertFinalNewline": true,
     "files.trimFinalNewlines": true,
-    "files.trimTrailingWhitespace": true,
+    "files.trimTrailingWhitespace": true
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,11 @@ FROM mcr.microsoft.com/devcontainers/base:alpine
 
 LABEL org.opencontainers.image.authors="Ryan Boehning <1250684+ryboe@users.noreply.github.com>"
 
-ARG ARCHITECTURE="amd64"
-
 # Install the latest gh CLI tool. The first request fetches the URL for the
 # latest release tarball. The second request downloads the tarball.
 RUN <<-EOT
   wget --quiet --timeout=30 --output-document=- 'https://api.github.com/repos/cli/cli/releases/latest' |
-  jq -r ".assets[] | select(.name | test(\"gh_.*?_linux_${ARCHITECTURE}.tar.gz\")).browser_download_url" |
+  jq -r ".assets[] | select(.name | test(\"gh_.*?_linux_amd64.tar.gz\")).browser_download_url" |
   wget --quiet --timeout=180 --input-file=- --output-document=- |
   sudo tar -xvz -C /usr/local/ --strip-components=1
 EOT


### PR DESCRIPTION
Also remove the ARCHITECTURE build arg because codespaces only support AMD64 architecture.