### PR TITLE
fix: keep 10 most recently pushed images

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -17,4 +17,4 @@ jobs:
           package-name: alpinecodespace
           package-type: container
           delete-only-untagged-versions: "true"
-          min-versions-to-keep: 0
+          min-versions-to-keep: 10


### PR DESCRIPTION
The workflow that cleans up untagged images was failing with an error. It was mistakenly trying to delete provenance/SBOM information associated with the latest image. Keeping the 10 most recently pushed images will prevent this.
