### PR TITLE
fix: use third-party library for cleaning up untagged images

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -6,15 +6,10 @@ on:
   workflow_dispatch:
 
 jobs:
-  cleanup_untagged_images:
+  clean_up_untagged_images:
     runs-on: ubuntu-latest
-    permissions:
-      packages: write
     steps:
       - name: Delete untagged images
-        uses: actions/delete-package-versions@v5
+        uses: dataaxiom/ghcr-cleanup-action@v1
         with:
-          package-name: alpinecodespace
-          package-type: container
-          delete-only-untagged-versions: "true"
-          min-versions-to-keep: 10
+          delete-untagged: true


### PR DESCRIPTION
`actions/delete-package-version` doesn't work with SBOM for some reason.
